### PR TITLE
Redirection error when viewing a vacancy

### DIFF
--- a/pages/vacancies/_id.vue
+++ b/pages/vacancies/_id.vue
@@ -156,7 +156,6 @@ export default Vue.extend({
   },
   mounted() {
     if (
-      !this.$auth.isVacanciesAdmin || 
       !this.$route.params.id
     ) {
       this.$router.push('/vacancies')


### PR DESCRIPTION
Removed the requirement to be a vacancies admin when viewing a vacancy.